### PR TITLE
Add flake8 config file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,18 @@
+[flake8]
+ignore =
+    # Line too long
+    E501,
+    # Missing whitespace around arithmetic operator
+    E226,
+    # Module level import not at top of file
+    E402,
+    # Do not use variables named "I", "O", or "l"
+    E741,
+    # Unable to detect undefined names
+    F403,
+    # Name may be undefined, or defined from star imports
+    F405,
+    # Line break occurred before binary operator
+    W503
+max-line-length = 88
+select = B,C,E,F,W,T4,B9

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install:
 
 lint:
 	@echo "Checking lint..."
-	@flake8 --ignore=E501,E226,E402,E741,F403,F405,W503
+	@flake8
 	@echo "PASS"
 
 test: lint


### PR DESCRIPTION
Closes #10.

Flake8 is a tool for checking formatting meets certain requirements. I find the full PEP requirements to be a bit strict so recommend ignoring a few of them.

This PR puts the configuration for which checks to ignore in a file. This makes it easier to understand what's going on.