### PR TITLE
Provide paths to PSyclone classes

### DIFF
--- a/psyacc/assignment.py
+++ b/psyacc/assignment.py
@@ -12,6 +12,6 @@ def is_literal_assignment(node):
     """
     Determine whether a Node corresponds to an assignment of a literal value.
 
-    :arg node: the :class:`Node` in question
+    :arg node: the :class:`psyclone.psyir.nodes.node.Node` in question
     """
     return isinstance(node, nodes.Assignment) and isinstance(node.rhs, nodes.Literal)

--- a/psyacc/clauses.py
+++ b/psyacc/clauses.py
@@ -27,7 +27,7 @@ def _prepare_loop_for_clause(loop):
     """
     Prepare to apply a clause to a ``loop`` directive.
 
-    :arg loop: the :class:`Loop` node.
+    :arg loop: the :class:`psyclone.psyir.nodes.loop.Loop` node.
     """
     _check_loop(loop)
     if not has_kernels_directive(loop):
@@ -40,7 +40,7 @@ def has_seq_clause(loop):
     """
     Determine whether a loop has a ``seq`` clause.
 
-    :arg loop: the :class:`Loop` node.
+    :arg loop: the :class:`psyclone.psyir.nodes.loop.Loop` node.
     """
     return has_loop_directive(loop) and loop.parent.parent.sequential
 
@@ -51,7 +51,7 @@ def apply_loop_seq(loop):
 
     A ``loop`` directive is also applied, if it does not already exist.
 
-    :arg loop: the :class:`Loop` node.
+    :arg loop: the :class:`psyclone.psyir.nodes.loop.Loop` node.
     """
     _prepare_loop_for_clause(loop)
     if has_gang_clause(loop):
@@ -65,7 +65,7 @@ def has_gang_clause(loop):
     """
     Determine whether a loop has a ``gang`` clause.
 
-    :arg loop: the :class:`Loop` node.
+    :arg loop: the :class:`psyclone.psyir.nodes.loop.Loop` node.
     """
     return has_loop_directive(loop) and loop.parent.parent.gang
 
@@ -76,7 +76,7 @@ def apply_loop_gang(loop):
 
     A ``loop`` directive is also applied, if it does not already exist.
 
-    :arg loop: the :class:`Loop` node.
+    :arg loop: the :class:`psyclone.psyir.nodes.loop.Loop` node.
     """
     _prepare_loop_for_clause(loop)
     if has_seq_clause(loop):
@@ -88,7 +88,7 @@ def has_vector_clause(loop):
     """
     Determine whether a loop has a ``vector`` clause.
 
-    :arg loop: the :class:`Loop` node.
+    :arg loop: the :class:`psyclone.psyir.nodes.loop.Loop` node.
     """
     return has_loop_directive(loop) and loop.parent.parent.vector
 
@@ -99,7 +99,7 @@ def apply_loop_vector(loop):
 
     A ``loop`` directive is also applied, if it does not already exist.
 
-    :arg loop: the :class:`Loop` node.
+    :arg loop: the :class:`psyclone.psyir.nodes.loop.Loop` node.
     """
     _prepare_loop_for_clause(loop)
     if has_seq_clause(loop):
@@ -111,7 +111,7 @@ def has_collapse_clause(loop):
     """
     Determine whether a loop lies within a collapsed loop nest.
 
-    :arg loop: the :class:`Loop` node.
+    :arg loop: the :class:`psyclone.psyir.nodes.loop.Loop` node.
     """
     _check_loop(loop)
     if not has_kernels_directive(loop):
@@ -134,7 +134,7 @@ def apply_loop_collapse(loop, collapse=None):
 
     A ``loop`` directive is also applied, if it does not already exist.
 
-    :arg loop: the :class:`Loop` node.
+    :arg loop: the :class:`psyclone.psyir.nodes.loop.Loop` node.
     :kwarg collapse: the number of loops to collapse
     """
     _prepare_loop_for_clause(loop)

--- a/psyacc/convert.py
+++ b/psyacc/convert.py
@@ -17,7 +17,8 @@ def convert_array_notation(schedule):
     """
     Convert implicit array range assignments into explicit ones.
 
-    Wrapper for the :meth:`apply` method of :class:`Reference2ArrayRangeTrans`.
+    Wrapper for the :meth:`apply` method of
+    :class:`psyclone.psyir.transformations.reference2arrayrange_trans.Reference2ArrayRangeTrans`.
     """
     for reference in schedule.walk(nodes.Reference, stop_type=nodes.Reference):
         if has_ancestor(reference, nodes.Call):
@@ -33,7 +34,8 @@ def convert_range_loops(schedule):
     """
     Convert explicit array range assignments into loops.
 
-    Wrapper for the :meth:`apply` method of :class:`NemoArrayRange2LoopTrans`.
+    Wrapper for the :meth:`apply` method of
+    :class:`psyclone.domain.nemo.transformations.nemo_arrayrange2loop_trans.NemoArrayRange2LoopTrans`.
     """
     before = str(schedule)
     for r in schedule.walk(nodes.Range):

--- a/psyacc/directives.py
+++ b/psyacc/directives.py
@@ -47,7 +47,7 @@ def apply_loop_directive(loop, options={}):
     """
     Apply a ``loop`` directive.
 
-    :arg loop: the :class:`Loop` node.
+    :arg loop: the :class:`psyclone.psyir.nodes.loop.Loop` node.
     :kwarg options: a dictionary of clause options.
     """
     if not isinstance(loop, nodes.Loop):

--- a/psyacc/family.py
+++ b/psyacc/family.py
@@ -146,7 +146,8 @@ def has_ancestor(node, node_type=nodes.Loop, name=None, inclusive=False):
 
 def are_siblings(*nodes):
     r"""
-    Determine whether a collection of :class:`Node`\s have the same parent.
+    Determine whether a collection of :class:`psyclone.psyir.nodes.node.Node`\s have the
+    same parent.
     """
     assert len(nodes) > 1
     return all([node in nodes[0].siblings for node in nodes])
@@ -154,7 +155,8 @@ def are_siblings(*nodes):
 
 def is_next_sibling(node1, node2):
     """
-    Determine whether one :class:`Node` immediately follows another.
+    Determine whether one :class:`psyclone.psyir.nodes.node.Node` immediately follows
+    another.
 
     :arg node1: the first node.
     :arg node2: the second node.

--- a/psyacc/loop.py
+++ b/psyacc/loop.py
@@ -23,7 +23,7 @@ __all__ = [
 
 def _check_loop(loop):
     """
-    Check that we do indeed have a :class:`Loop` node.
+    Check that we do indeed have a :class:`psyclone.psyir.nodes.loop.Loop` node.
     """
     if not isinstance(loop, nodes.Loop):
         raise TypeError(f"Expected a Loop, not '{type(loop)}'.")
@@ -41,7 +41,7 @@ def loop2nest(loop):
     """
     Given a loop, obtain all of its descendent loops (inclusive).
 
-    :arg loop: the :class:`Loop`
+    :arg loop: the :class:`psyclone.psyir.nodes.loop.Loop`
     """
     _check_loop(loop)
     return get_descendents(loop, node_type=nodes.Loop, inclusive=True)
@@ -64,13 +64,14 @@ def is_perfectly_nested(outer_loop_or_subnest):
     Determine whether a loop (sub)nest is perfect, i.e., each level except the deepest
     contains only the next loop.
 
-    Note that we ignore nodes of type :class:`Literal` and :class:`Reference`.
+    Note that we ignore nodes of type :class:`psyclone.psyir.nodes.literal.Literal` and
+    :class:`psyclone.psyir.nodes.reference.Reference`.
 
     Note also that the 'outer loop' here is not necessarily the outer-most loop in the
     schedule, just the outer-most loop in the sub-nest.
 
     :arg outer_loop_or_subnest: either the outer loop of the subnest, or the subnest as
-        a list of :class:`Loop`\s
+        a list of :class:`psyclone.psyir.nodes.loop.Loop`\s
     """
     exclude = (
         nodes.literal.Literal,
@@ -90,7 +91,8 @@ def is_perfectly_nested(outer_loop_or_subnest):
     def intersect(list1, list2):
         r"""
         Return the intersection of two lists. Note that we cannot use the in-built set
-        intersection functionality because PSyclone :class:`Node`\s are not hashable.
+        intersection functionality because PSyclone
+        :class:`psyclone.psyir.nodes.node.Node`\s are not hashable.
         """
         return [item for item in list1 if item in list2]
 
@@ -136,7 +138,7 @@ def is_simple_loop(loop):
 
 def get_loop_variable_name(loop):
     """
-    Given a :class:`Loop` node, return its variable name.
+    Given a :class:`psyclone.psyir.nodes.loop.Loop` node, return its variable name.
     """
     assert isinstance(loop, nodes.Loop)
     return loop.variable.name
@@ -144,8 +146,8 @@ def get_loop_variable_name(loop):
 
 def get_loop_nest_variable_names(loop):
     """
-    Given a :class:`Loop` node, return the variable names of each loop it
-    contains.
+    Given a :class:`psyclone.psyir.nodes.loop.Loop` node, return the variable names of
+    each loop it contains.
     """
     assert isinstance(loop, nodes.Loop)
     return [get_loop_variable_name(loop) for loop in loop2nest(loop)]
@@ -153,7 +155,8 @@ def get_loop_nest_variable_names(loop):
 
 def is_independent(loop):
     """
-    Determine whether a perfectly nested :class:`Loop` is independent.
+    Determine whether a perfectly nested :class:`psyclone.psyir.nodes.loop.Loop` is
+    independent.
     """
     if not is_perfectly_nested(loop):
         raise ValueError(
@@ -175,8 +178,9 @@ def is_independent(loop):
 
 def is_parallelisable(loop):
     """
-    Determine whether a :class:`Loop` can be parallelised.
+    Determine whether a :class:`psyclone.psyir.nodes.loop.Loop` can be parallelised.
 
-    Note: wraps the :meth:`can_loop_be_parallelised` method of :class:`DependencyTools`.
+    Note: wraps the :meth:`can_loop_be_parallelised` method of
+    :class:`psyclone.psyir.tools.dependency_tools.DependencyTools`.
     """
     return DependencyTools().can_loop_be_parallelised(loop)

--- a/psyacc/types.py
+++ b/psyacc/types.py
@@ -11,7 +11,8 @@ __all__ = ["is_character", "refers_to_character"]
 
 def is_character(node):
     """
-    Determine whether a :class:`Reference` is of type `CHARACTER`.
+    Determine whether a :class:`psyclone.psyir.nodes.reference.Reference` has Fortran
+    type `CHARACTER`.
     """
     assert isinstance(node, nodes.Reference)
     return "CHARACTER" in node.datatype.type_text
@@ -19,6 +20,7 @@ def is_character(node):
 
 def refers_to_character(node):
     r"""
-    Determine whether a Node contains references to `CHARACTER`\s.
+    Determine whether a :class:`psyclone.psyir.nodes.node.Node` contains references to
+    Fortran `CHARACTER`\s.
     """
     return any([is_character(ref) for ref in get_descendents(node, nodes.Reference)])


### PR DESCRIPTION
Closes #42.

This PR provides the proper paths for all references to PSyclone objects in the docs.

However, it won't give useful output until #32 is fixed.