### PR TITLE
Update test_suite.yml

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -32,7 +32,7 @@ jobs:
           git clone https://github.com/stfc/PSyclone.git
           cd PSyclone
           python3 -m pip install -r requirements.txt
-          python3 -m pip install .
+          python3 -m pip install -e .
 
       - name: Install PSyACC
         run: |


### PR DESCRIPTION
Test suite has been failing citing "no module named psyclone.tests". Tried to do the testing locally and it works fine. Only difference I can see is that there is no `-e` in the test suite yaml file. Probably won't fix but will try.