### PR TITLE
#98 Add testing for current LFRic PSyclone version

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -1,4 +1,4 @@
-name: Test suite
+name: PSyclone HEAD test suite
 
 on:
   # Trigger the workflow on certain events
@@ -13,7 +13,7 @@ on:
 
 jobs:
 
-  test_suite:
+  psyclone_HEAD_test:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test_suite_lfric_psyclone.yml
+++ b/.github/workflows/test_suite_lfric_psyclone.yml
@@ -1,19 +1,20 @@
-name: Test suite
+name: LFRic-PSyclone test suite
 
 on:
   # Trigger the workflow on certain events
   pull_request:
+    branches:
+      - "main"
+  push:
+    branches:
+      - "main"
 
   # Enable manual triggering from the Actions tab
   workflow_dispatch:
 
-  # Trigger the workflow every Saturday at 17:00 UTC
-  schedule:
-    - cron: "0 17 * * 6"
-
 jobs:
 
-  test_suite:
+  lfric_psyclone_test:
 
     runs-on: ubuntu-latest
 
@@ -25,11 +26,11 @@ jobs:
           cd /home/runner/work
           python3 -m venv psytran-ci
 
-      - name: Install PSyclone HEAD
+      - name: Install LFRic PSyclone (v3.1.0)
         run: |
           source /home/runner/work/psytran-ci/bin/activate
           cd /home/runner/work
-          git clone https://github.com/stfc/PSyclone.git
+          git clone -b v3.1.0 --single-branch https://github.com/stfc/PSyclone.git PSyclone
           cd PSyclone
           python3 -m pip install -r requirements.txt
           python3 -m pip install -e .


### PR DESCRIPTION
Closes #98

In preparation for the feature-based release structure, this ticket sets up testing of the current PSyclone version used by LFRic (3.1.0). This will have to be manually changed whenever LFRic updates the PSyclone version.