### PR TITLE
#110 Remove pre-commit install from make install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,7 @@ install:
 	@python3 -m pip install --upgrade pip
 	@echo "Done."
 	@echo "Installing psytran..."
-	@python3 -m pip install -e .
-	@echo "Done."
-	@echo "Setting up pre-commit..."
-	@pre-commit install
+	@python3 -m pip install .
 	@echo "Done."
 
 install_dev:


### PR DESCRIPTION
Closes #110 :

The current `make install` target builds additional things that are not needed by those who are just trying to use the PSyTran library - pre-commit.

This should be removed to improve build time and only give what's needed. The `install_dev` target will still build the pre-commit.